### PR TITLE
[fix][fn]Support for pulsar.service.url in the Local Run Mode for Debezium IO connectors

### DIFF
--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -445,6 +445,14 @@ public class LocalRunner implements AutoCloseable {
             if (webServiceUrl == null) {
                 webServiceUrl = DEFAULT_WEB_SERVICE_URL;
             }
+            if (sourceConfig != null && sourceConfig.getConfigs() != null
+                    && sourceConfig.getConfigs().get("pulsar.service.url") != null){
+                serviceUrl = (String) sourceConfig.getConfigs().get("pulsar.service.url");
+            }
+            if (sinkConfig != null && sinkConfig.getConfigs() != null
+                    && sinkConfig.getConfigs().get("pulsar.service.url") != null){
+                serviceUrl = (String) sinkConfig.getConfigs().get("pulsar.service.url");
+            }
 
             if ((sourceConfig != null || sinkConfig != null
                     || functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA)

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -442,16 +442,18 @@ public class LocalRunner implements AutoCloseable {
             if (brokerServiceUrl != null) {
                 serviceUrl = brokerServiceUrl;
             }
+            else {
+                if (sourceConfig != null && sourceConfig.getConfigs() != null
+                        && sourceConfig.getConfigs().get("pulsar.service.url") != null){
+                    serviceUrl = (String) sourceConfig.getConfigs().get("pulsar.service.url");
+                }
+                if (sinkConfig != null && sinkConfig.getConfigs() != null
+                        && sinkConfig.getConfigs().get("pulsar.service.url") != null){
+                    serviceUrl = (String) sinkConfig.getConfigs().get("pulsar.service.url");
+                }
+            }
             if (webServiceUrl == null) {
                 webServiceUrl = DEFAULT_WEB_SERVICE_URL;
-            }
-            if (sourceConfig != null && sourceConfig.getConfigs() != null
-                    && sourceConfig.getConfigs().get("pulsar.service.url") != null){
-                serviceUrl = (String) sourceConfig.getConfigs().get("pulsar.service.url");
-            }
-            if (sinkConfig != null && sinkConfig.getConfigs() != null
-                    && sinkConfig.getConfigs().get("pulsar.service.url") != null){
-                serviceUrl = (String) sinkConfig.getConfigs().get("pulsar.service.url");
             }
 
             if ((sourceConfig != null || sinkConfig != null

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -441,8 +441,7 @@ public class LocalRunner implements AutoCloseable {
             String serviceUrl = DEFAULT_SERVICE_URL;
             if (brokerServiceUrl != null) {
                 serviceUrl = brokerServiceUrl;
-            }
-            else {
+            } else {
                 if (sourceConfig != null && sourceConfig.getConfigs() != null
                         && sourceConfig.getConfigs().get("pulsar.service.url") != null){
                     serviceUrl = (String) sourceConfig.getConfigs().get("pulsar.service.url");


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes [21276](https://github.com/apache/pulsar/issues/21276) of apache/pulsar

### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Local run mode which is used for debugging functions doesn't support pulsar.service.url from Debezium IO connectors. It is always picking up the default value of "pulsar://localhost:6650".

### Modifications

<!-- Describe the modifications you've done. -->
Modified so that it picks the broker url specified in "pulsar.service.url" from source or sink config if specified. The priority will be "--brokerServiceUrl" if specified and if not, it will pick up pulsar.service.url from source or sink config.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
