### PR TITLE
[improve][misc] Upgrade debezium version from 1.9.7.Final to 3.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,10 +241,10 @@ flexible messaging model and an intuitive client API.</description>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
+    <debezium.version>3.2.0.Final</debezium.version>
     <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>2.6.1.Final</debezium.version>
-    <debezium.postgresql.version>42.5.5</debezium.postgresql.version>
-    <debezium.mysql.version>8.0.33</debezium.mysql.version>
+    <debezium.postgresql.version>42.7.7</debezium.postgresql.version>
+    <debezium.mysql.version>9.1.0</debezium.mysql.version>
     <!-- Override version that brings CVE-2022-3143 with debezium -->
     <wildfly-elytron.version>1.15.16.Final</wildfly-elytron.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@ flexible messaging model and an intuitive client API.</description>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>1.9.7.Final</debezium.version>
+    <debezium.version>2.6.1.Final</debezium.version>
     <debezium.postgresql.version>42.5.5</debezium.postgresql.version>
     <debezium.mysql.version>8.0.33</debezium.mysql.version>
     <!-- Override version that brings CVE-2022-3143 with debezium -->

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -88,7 +88,7 @@ public abstract class DebeziumSource extends KafkaConnectSource {
         setConfigIfNull(config, PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, DEFAULT_CONVERTER);
 
         // database.history : implementation class for database history.
-        setConfigIfNull(config, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name(), DEFAULT_HISTORY);
+        setConfigIfNull(config, HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.name(), DEFAULT_HISTORY);
 
         // database.history.pulsar.service.url
         String pulsarUrl = (String) config.get(PulsarDatabaseHistory.SERVICE_URL.name());

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -26,8 +26,8 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
-import io.debezium.relational.history.DatabaseHistory;
-import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
 import java.io.ByteArrayOutputStream;
@@ -79,8 +79,8 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
                                          boolean testWithReaderConfig) throws Exception {
         Configuration.Builder configBuidler = Configuration.create()
                 .with(PulsarDatabaseHistory.TOPIC, topicName)
-                .with(DatabaseHistory.NAME, "my-db-history")
-                .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
+                .with(SchemaHistory.NAME, "my-db-history")
+                .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
 
         if (testWithClientBuilder) {
             ClientBuilder builder = PulsarClient.builder().serviceUrl(brokerUrl.toString());
@@ -100,7 +100,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         }
 
         // Start up the history ...
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // Should be able to call start more than once ...
@@ -160,7 +160,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         // Stop the history (which should stop the producer) ...
         history.stop();
         history = new PulsarDatabaseHistory();
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         // no need to start
 
         // Recover from the very beginning to just past the first change ...
@@ -246,11 +246,11 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         Configuration config = Configuration.create()
             .with(PulsarDatabaseHistory.SERVICE_URL, brokerUrl.toString())
             .with(PulsarDatabaseHistory.TOPIC, "persistent://my-property/my-ns/dummytopic")
-            .with(DatabaseHistory.NAME, "my-db-history")
-            .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
+            .with(SchemaHistory.NAME, "my-db-history")
+            .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
             .build();
 
-        history.configure(config, null, DatabaseHistoryListener.NOOP, true);
+        history.configure(config, null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // dummytopic should not exist yet

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
@@ -25,7 +25,7 @@ public class DebeziumMongoDbContainer extends ChaosContainer<DebeziumMongoDbCont
     public static final String NAME = "debezium-mongodb-example";
 
     public static final Integer[] PORTS = { 27017 };
-    private static final String IMAGE_NAME = "debezium/example-mongodb:0.10";
+    private static final String IMAGE_NAME = "debezium/example-mongodb:2.5.0.Final";
 
     public DebeziumMongoDbContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
@@ -26,7 +26,7 @@ public class DebeziumMySQLContainer extends ChaosContainer<DebeziumMySQLContaine
     public static final String NAME = "debezium-mysql-example";
     static final Integer[] PORTS = { 3306 };
 
-    private static final String IMAGE_NAME = "debezium/example-mysql:0.8";
+    private static final String IMAGE_NAME = "debezium/example-mysql:2.5.0.Final";
 
     public DebeziumMySQLContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
@@ -26,7 +26,7 @@ public class DebeziumPostgreSqlContainer extends ChaosContainer<DebeziumPostgreS
     public static final String NAME = "debezium-postgresql-example";
     static final Integer[] PORTS = { 5432 };
 
-    private static final String IMAGE_NAME = "debezium/example-postgres:0.10";
+    private static final String IMAGE_NAME = "debezium/example-postgres:2.5.0.Final";
 
     public DebeziumPostgreSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
@@ -52,12 +52,18 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> i
     protected int numEntriesToInsert = 1;
     protected int numEntriesExpectAfterStart = 9;
 
+    /*
+     *In Debezium 2.5, they introduced several new timestamp fields,
+     * ts_us, and ts_ns, which represent the millisecond-based time values in microseconds and nanoseconds respectively.
+     */
     public static final Set<String> DEBEZIUM_FIELD_SET = new HashSet<String>() {{
         add("before");
         add("after");
         add("source");
         add("op");
         add("ts_ms");
+        add("ts_us");
+        add("ts_ns");
         add("transaction");
     }};
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -42,15 +42,21 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         this.pulsarCluster = cluster;
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
-        sourceConfig.put("mongodb.hosts", "rs0/" + DebeziumMongoDbContainer.NAME + ":27017");
+        /*
+         *The `mongodb.connection.string` property replaces the deprecated `mongodb.hosts` property in release 2.2
+         * that was used to provide earlier versions of the connector with the host address of the configuration server replica.
+         * In the current release, use mongodb.connection.string to provide the connector with the addresses of MongoDB routers,
+         * also known as mongos.
+         */
+        sourceConfig.put("connector.class", "io.debezium.connector.mongodb.MongoDbConnector");
+        sourceConfig.put("mongodb.connection.string", "mongodb://" + DebeziumMongoDbContainer.NAME + ":27017/?replicaSet=rs0");
         sourceConfig.put("mongodb.name", "dbserver1");
         sourceConfig.put("mongodb.user", "debezium");
         sourceConfig.put("mongodb.password", "dbz");
         sourceConfig.put("mongodb.task.id", "1");
-        sourceConfig.put("database.include.list", "inventory");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mongodb");
-        sourceConfig.put("capture.mode", "oplog");
+        sourceConfig.put("topic.prefix", "dbserver1");
     }
 
     @Override
@@ -66,41 +72,44 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         log.info("debezium mongodb server already contains preconfigured data.");
     }
 
+    /*
+     * mongo is deprecated in 2.6.1.Final release and now we have use mongosh instead
+     */
     @Override
     public void prepareInsertEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.insert({ "
-                        + "_id : NumberLong(\"110\"),"
-                        + "name : \"test-debezium\","
-                        + "description: \"24 inch spare tire\","
-                        + "weight : 22.2,"
-                        + "quantity : NumberInt(\"5\")})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.insert({ " +
+                        "_id : NumberLong(\"110\")," +
+                        "name : \"test-debezium\"," +
+                        "description: \"24 inch spare tire\"," +
+                        "weight : 22.2," +
+                        "quantity : NumberInt(\"5\")})'");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.update({"
-                        + "_id : 110},"
-                        + "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.update({" +
+                        "_id : 110}," +
+                        "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -54,15 +54,18 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
 
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
+        sourceConfig.put("connector.class", "io.debezium.connector.sqlserver.SqlServerConnector");
         sourceConfig.put("database.hostname", DebeziumMsSqlContainer.NAME);
         sourceConfig.put("database.port", "1433");
         sourceConfig.put("database.user", "sa");
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
         sourceConfig.put("database.server.name", "mssql");
-        sourceConfig.put("database.dbname", "TestDB");
-        sourceConfig.put("snapshot.mode", "schema_only");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("database.names", "TestDB");
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mssql");
+        sourceConfig.put("topic.prefix", "mssql");
+        sourceConfig.put("database.encrypt", "false");
+        sourceConfig.put("task.id", "1");
     }
 
     @Override
@@ -145,12 +148,12 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
 
     @Override
     public String keyContains() {
-        return "mssql.dbo.customers.Key";
+        return "mssql.TestDB.dbo.customers.Key";
     }
 
     @Override
     public String valueContains() {
-        return "mssql.dbo.customers.Value";
+        return "mssql.TestDB.dbo.customers.Value";
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -32,7 +32,7 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
  * It reads binlog from MySQL, and store the debezium output into Pulsar.
  * This test verify that the target topic contains wanted number messages.
  *
- * Debezium MySQL Container is "debezium/example-mysql:0.8",
+ * Debezium MySQL Container is "debezium/example-mysql:2.5.0.Final",
  * which is a MySQL database server preconfigured with an inventory database.
  */
 @Slf4j
@@ -53,6 +53,7 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
         this.pulsarCluster = cluster;
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
+        sourceConfig.put("connector.class", "io.debezium.connector.mysql.MySqlConnector");
         sourceConfig.put("database.hostname", DebeziumMySQLContainer.NAME);
         sourceConfig.put("database.port", "3306");
         sourceConfig.put("database.user", "debezium");
@@ -60,8 +61,10 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
         sourceConfig.put("database.server.id", "184054");
         sourceConfig.put("database.server.name", "dbserver1");
         sourceConfig.put("database.whitelist", "inventory");
+        sourceConfig.put("database.include.list", "inventory");
+        sourceConfig.put("topic.prefix", "dbserver1");
         if (!testWithClientBuilder) {
-            sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+            sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         }
         sourceConfig.put("key.converter", converterClassName);
         sourceConfig.put("value.converter", converterClassName);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
@@ -50,21 +50,22 @@ public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbC
         super(NAME);
         this.pulsarCluster = cluster;
         this.numEntriesToInsert = 1;
-        this.numEntriesExpectAfterStart = 0;
+        this.numEntriesExpectAfterStart = 1;
 
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
+        sourceConfig.put("connector.class", "io.debezium.connector.oracle.OracleConnector");
         sourceConfig.put("database.hostname", DebeziumOracleDbContainer.NAME);
         sourceConfig.put("database.port", "1521");
         sourceConfig.put("database.user", "dbzuser");
         sourceConfig.put("database.password", "dbz");
         sourceConfig.put("database.server.name", "XE");
         sourceConfig.put("database.dbname", "XE");
-        sourceConfig.put("snapshot.mode", "schema_only");
-
+        sourceConfig.put("database.whitelist", "inv");
         sourceConfig.put("schema.include.list", "inv");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/oracle");
+        sourceConfig.put("topic.prefix", "XE");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -35,7 +35,7 @@ import org.testng.Assert;
  * It reads binlog from Postgres, and store the debezium output into Pulsar.
  * This test verify that the target topic contains wanted number messages.
  *
- * Debezium Postgresql Container is "debezium/example-postgres:0.10",
+ * Debezium Postgresql Container is "debezium/example-postgres:2.5.0.Final",
  * which is a Postgresql database server preconfigured with an inventory database.
  */
 @Slf4j
@@ -66,6 +66,7 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
 
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
+        sourceConfig.put("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
         sourceConfig.put("database.hostname", DebeziumPostgreSqlContainer.NAME);
         sourceConfig.put("database.port", "5432");
         sourceConfig.put("database.user", "postgres");
@@ -75,8 +76,9 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("database.dbname", "postgres");
         sourceConfig.put("schema.whitelist", "inventory");
         sourceConfig.put("table.blacklist", "inventory.spatial_ref_sys,inventory.geom");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/postgresql");
+        sourceConfig.put("topic.prefix", "dbserver1");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumOracleSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumOracleSourceTest.java
@@ -55,7 +55,7 @@ public class PulsarDebeziumOracleSourceTest extends PulsarIOTestBase {
         final String sourceName = "test-source-debezium-oracle-" + functionRuntimeType + "-" + randomName(8);
 
         // This is the event count to be created by prepareSource.
-        final int numMessages = 39;
+        final int numMessages = 2;
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumOracleSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumOracleSourceTest.java
@@ -55,7 +55,7 @@ public class PulsarDebeziumOracleSourceTest extends PulsarIOTestBase {
         final String sourceName = "test-source-debezium-oracle-" + functionRuntimeType + "-" + randomName(8);
 
         // This is the event count to be created by prepareSource.
-        final int numMessages = 1;
+        final int numMessages = 39;
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
@@ -91,7 +91,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
                 + "-" + functionRuntimeType + "-" + randomName(8);
 
         // This is the binlog count that contained in mysql container.
-        final int numMessages = 47;
+        final int numMessages = 52;
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()
@@ -138,7 +138,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         final String sourceName = "test-source-debezium-postgersql-" + functionRuntimeType + "-" + randomName(8);
 
         // This is the binlog count that contained in postgresql container.
-        final int numMessages = 26;
+        final int numMessages = 29;
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()
@@ -214,7 +214,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         final String tenant = TopicName.PUBLIC_TENANT;
         final String namespace = TopicName.DEFAULT_NAMESPACE;
         final String outputTopicName = "debe-output-topic-name-" + testId.getAndIncrement();
-        final String consumeTopicName = "debezium/mssql/mssql.dbo.customers";
+        final String consumeTopicName = "debezium/mssql/mssql.TestDB.dbo.customers";
         final String sourceName = "test-source-debezium-mssql-" + functionRuntimeType + "-" + randomName(8);
 
         final int numMessages = 1;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24888 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Debezium 3.2.0.Final includes significant improvements over 1.9.7.Final, such as:
- Better performance and stability
- Support for newer database versions
- Bug fixes and security updates
Upgrading will improve Pulsar IO Debezium connector reliability and compatibility with modern database deployments.

### Modifications
- Upgraded Debezium dependency from 1.9.7.Final to 3.2.0.Final in the relevant module(s)
- Upgraded the PostreSQL and MySQL driver versions to be compatible with new debezium version
- Updated the numMessages in test case (PulsarDebeziumOracleSourceTest#testDebeziumOracleDbSource) from 39 to 2 as the new debezium source connector does not process the internal messages (related to SYS.LOGMNRLT). Previously, the value was 39, which was composed of 37 internal messages and 2 messages ( 1- Create the customer table and 1- Insertion into the table).
- Refactored database history to schema history
- Upgraded debezium mongodb, mysql, postgres image to 2.5.0.Final
- Added new timestamp fields which were introduced in debezium 2.5
- Replaced mongo with mongosh, mongo was deprecated in debezium 2.6.1.Final
- Modified mongodb sourcetester to use the new config values
- Modified mssql sourcetester to use the new config values
- Modified mysql sourcetester to use the new config values
- Modified postgres sourcetester to use the new config values
- Modified oracle sourcetester to use the new config values
### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->