### PR TITLE
[fix][broker] Force EnsemblePolicies to resolve network location after rackInfoMap is updated due to changes in /ledgers/available znode

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -170,10 +170,14 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
         }
     }
 
-    private synchronized Void processRackUpdate(BookiesRackConfiguration racks) {
-        updateRacksWithHost(racks);
+    private Void processRackUpdate(BookiesRackConfiguration racks) {
+        ArrayList<BookieId> bookieIdSet;
+        synchronized (this) {
+            updateRacksWithHost(racks);
+            bookieIdSet = new ArrayList<>(bookieAddressListLastTime);
+        }
         // Notify ensemble placement policy after rack info is updated to ensure consistent state.
-        rackChangeListenerCallback(new ArrayList<>(bookieAddressListLastTime));
+        rackChangeListenerCallback(bookieIdSet);
         return null;
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -173,9 +173,8 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
     }
 
     private Void processRackUpdate(BookiesRackConfiguration racks, List<BookieId> bookieAddressListLastTime) {
-        // Step 1: update internal rack map
         updateRacksWithHost(racks);
-        // Step 2: notify REPP about rack changes
+        // Adding callback after rackInfo is updated by change in writable bookies.
         rackChangeListenerCallback(bookieAddressListLastTime);
         return null;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java
@@ -174,7 +174,7 @@ public class BookieRackAffinityMapping extends AbstractDNSToSwitchMapping
 
     private Void processRackUpdate(BookiesRackConfiguration racks, List<BookieId> bookieAddressListLastTime) {
         updateRacksWithHost(racks);
-        // Adding callback after rackInfo is updated by change in writable bookies.
+        // Notify ensemble placement policy after rack info is updated to ensure consistent state.
         rackChangeListenerCallback(bookieAddressListLastTime);
         return null;
     }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -482,7 +482,7 @@ public class BookieRackAffinityMappingTest {
                 new Versioned<>(BookieServiceInfoUtils.buildLegacyBookieServiceInfo(bookie1.toString()), Version.NEW)
         );
 
-        // watcher.processWritableBookiesChanged runs FIRST triggering Rackaware ensemble policy listener → incorrect
+        // watcher.processWritableBookiesChanged runs FIRST triggering RackAware ensemble policy listener → incorrect
         // ordering
         Method procMethod =
                 watcherClazz.getDeclaredMethod("processWritableBookiesChanged", java.util.Set.class);
@@ -497,11 +497,6 @@ public class BookieRackAffinityMappingTest {
         processRackUpdateMethod.setAccessible(true);
         processRackUpdateMethod.invoke(mapping, racks, List.of(bookie1.toBookieId()));
 
-        // mapping.resolve now has correct rack (mapping is updated)
-//        List<String> resolved = mapping.resolve(Lists.newArrayList(bookie1.getHostName()));
-//        assertEquals(resolved.get(0), "/rack0",
-//                "Expected mapping to have /rack0 after update before watcher ran");
-
         // -------------------
         // NOW CHECK REPP INTERNAL STATE
         // -------------------
@@ -511,7 +506,7 @@ public class BookieRackAffinityMappingTest {
         field1.setAccessible(true);
         Map<BookieId, BookieNode> knownBookies = (Map<BookieId, BookieNode>) field1.get(repp);
         BookieNode bn = knownBookies.get(bookie1.toBookieId());
-        // Rack info update is delayed but because of new callback the rackinfo on ensemble policy should be updated.
+        // Rack info update is delayed but because of new callback the rack info on ensemble policy should be updated.
         assertEquals(bn.getNetworkLocation(), "/rack0",
                 "Network location should match /rack0 on bookie");
     }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -471,6 +471,11 @@ public class BookieRackAffinityMappingTest {
         when(mockCache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(racks)));
 
+        // Inject the bookie address list into BookieRackAffinityMapping
+        Field addressListField = BookieRackAffinityMapping.class.getDeclaredField("bookieAddressListLastTime");
+        addressListField.setAccessible(true);
+        addressListField.set(mapping, List.of(bookie1.toBookieId()));
+
         // Inject the writable bookie into PulsarRegistrationClient
         Field writableField = PulsarRegistrationClient.class.getDeclaredField("writableBookieInfo");
         writableField.setAccessible(true);
@@ -493,9 +498,9 @@ public class BookieRackAffinityMappingTest {
 
         // BookieRackAffinityMapping rack mapping update runs SECOND → delayed rack info
         Method processRackUpdateMethod = BookieRackAffinityMapping.class.getDeclaredMethod("processRackUpdate",
-                BookiesRackConfiguration.class, List.class);
+                BookiesRackConfiguration.class);
         processRackUpdateMethod.setAccessible(true);
-        processRackUpdateMethod.invoke(mapping, racks, List.of(bookie1.toBookieId()));
+        processRackUpdateMethod.invoke(mapping, racks);
 
         // -------------------
         // NOW CHECK REPP INTERNAL STATE

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMappingTest.java
@@ -419,7 +419,8 @@ public class BookieRackAffinityMappingTest {
     @Test
     public void testZKEventListenersOrdering() throws Exception {
         @Cleanup
-        PulsarRegistrationClient pulsarRegistrationClient = new PulsarRegistrationClient(store, "/ledgers");
+        PulsarRegistrationClient pulsarRegistrationClient =
+                new PulsarRegistrationClient(store, "/ledgers");
         DefaultBookieAddressResolver defaultBookieAddressResolver =
                 new DefaultBookieAddressResolver(pulsarRegistrationClient);
         // Create and configure the mapping
@@ -481,7 +482,8 @@ public class BookieRackAffinityMappingTest {
                 new Versioned<>(BookieServiceInfoUtils.buildLegacyBookieServiceInfo(bookie1.toString()), Version.NEW)
         );
 
-        // watcher.processWritableBookiesChanged runs FIRST triggering Rackaware ensemble policy listener → incorrect ordering
+        // watcher.processWritableBookiesChanged runs FIRST triggering Rackaware ensemble policy listener → incorrect
+        // ordering
         Method procMethod =
                 watcherClazz.getDeclaredMethod("processWritableBookiesChanged", java.util.Set.class);
         procMethod.setAccessible(true);
@@ -490,8 +492,8 @@ public class BookieRackAffinityMappingTest {
         procMethod.invoke(watcher, ids);
 
         // BookieRackAffinityMapping rack mapping update runs SECOND → delayed rack info
-        Method processRackUpdateMethod =
-                BookieRackAffinityMapping.class.getDeclaredMethod("processRackUpdate", BookiesRackConfiguration.class, List.class);
+        Method processRackUpdateMethod = BookieRackAffinityMapping.class.getDeclaredMethod("processRackUpdate",
+                BookiesRackConfiguration.class, List.class);
         processRackUpdateMethod.setAccessible(true);
         processRackUpdateMethod.invoke(mapping, racks, List.of(bookie1.toBookieId()));
 
@@ -510,7 +512,8 @@ public class BookieRackAffinityMappingTest {
         Map<BookieId, BookieNode> knownBookies = (Map<BookieId, BookieNode>) field1.get(repp);
         BookieNode bn = knownBookies.get(bookie1.toBookieId());
         // Rack info update is delayed but because of new callback the rackinfo on ensemble policy should be updated.
-        assertEquals(bn.getNetworkLocation(), "/rack0", "Network location should match /rack0 on bookie");
+        assertEquals(bn.getNetworkLocation(), "/rack0",
+                "Network location should match /rack0 on bookie");
     }
 
     private static HashedWheelTimer getTestHashedWheelTimer(ClientConfiguration bkClientConf) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #25058

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
WatchTask of Zookeeper [writableBookies](https://github.com/apache/bookkeeper/blob/2c5d98ebbe1ff8e935c4efd29aa92f37341452ec/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L383) has two listeners related to rackAwareness attached to it. [ZkBookieRackAffinityMapping](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker-common/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java) which extends [BookieRackAffinityMapping](https://github.com/apache/pulsar/blob/efa5e8b04018356447ec1744c6e083430e8e1f05/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/BookieRackAffinityMapping.java) and
[RackawareEnsemblePlacementPolicy](https://github.com/apache/bookkeeper/blob/fc981ba04bae126afe3452b76006e80487cc9d84/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java) which uses the ZkBookieRackAffinityMapping to resolve the network location.

If the listeners are called in the order of RackAwareEnsemblePlacementPolicy and then BookieRackAffinityMapping, the bookies in the ensemblePolicy are initially assigned to the `/default-rack` and stay there until there is a new ZKEvent on the list of writable bookies. We need to notify the ensemblePolicy after rack info is updated on the BookieRackAffinityMapping.


### Modifications

<!-- Describe the modifications you've done. -->

1. Updated BookieRackAffinityMapping listener to notify EnsemblePlacementPolicy onBookieRackChange after completing it's execution.
2. Added BookieRackAffinityMappingTest to replicate and  make sure the fix works.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMappingTest#testZKEventListenersOrdering*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
