### PR TITLE
[fix][client] Fix producer synchronous retry handling in failPendingMessages method

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-impl")
+public class ProducerSyncRetryTest extends ProducerConsumerBase {
+
+    @Override
+    @BeforeMethod
+    public void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @Override
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testProducerSyncRetryAfterTimeout() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp");
+        @Cleanup
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .sendTimeout(1, TimeUnit.MILLISECONDS) // force timeout
+                .create();
+
+        // To make sure first message is timed out
+        this.stopBroker();
+
+        // First message will get timed out, then be retried with same payload
+        ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
+        MessageMetadata messageMetadata = new MessageMetadata();
+        messageMetadata.setUncompressedSize(1);
+        MessageImpl<byte[]> message = MessageImpl.create(messageMetadata, payload, Schema.BYTES, topic);
+
+        MessageMetadata retryMessageMetadata = new MessageMetadata();
+        retryMessageMetadata.setUncompressedSize(1);
+        MessageImpl<byte[]> retryMessage = MessageImpl.create(messageMetadata, payload, Schema.BYTES, topic);
+
+        // First send is expected to fail
+        CompletableFuture<MessageId> firstSend = producer.sendAsync(message);
+
+        // Waits until firstSend returns timeout exception
+        CompletableFuture<MessageId> retrySend =
+                firstSend.handle((msgId, ex) -> {
+                    assertNotNull(ex, "First send must timeout");
+                    assertTrue(ex instanceof PulsarClientException.TimeoutException);
+                    try {
+                        // Retry should succeed
+                        this.startBroker();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    producer.conf.setSendTimeoutMs(10000);
+                    return producer.sendAsync(retryMessage);
+                }).thenCompose(f -> f);
+
+        // Wait until retry completes successfully
+        MessageId retryMessageId = retrySend.join();
+        assertNotNull(retryMessageId);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
@@ -71,7 +71,7 @@ public class ProducerSyncRetryTest extends ProducerConsumerBase {
 
         MessageMetadata retryMessageMetadata = new MessageMetadata();
         retryMessageMetadata.setUncompressedSize(1);
-        MessageImpl<byte[]> retryMessage = MessageImpl.create(messageMetadata, payload, Schema.BYTES, topic);
+        MessageImpl<byte[]> retryMessage = MessageImpl.create(retryMessageMetadata, payload, Schema.BYTES, topic);
 
         // First send is expected to fail
         CompletableFuture<MessageId> firstSend = producer.sendAsync(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerSyncRetryTest.java
@@ -75,6 +75,7 @@ public class ProducerSyncRetryTest extends ProducerConsumerBase {
 
         // First send is expected to fail
         CompletableFuture<MessageId> firstSend = producer.sendAsync(message);
+        producer.triggerSendTimer();
 
         // Waits until firstSend returns timeout exception
         CompletableFuture<MessageId> retrySend =

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2304,7 +2304,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      * This fails and clears the pending messages with the given exception. This method should be called from within the
      * ProducerImpl object mutex.
      */
-    private synchronized void failPendingMessages(ClientCnx cnx, PulsarClientException ex) {
+    @VisibleForTesting
+    synchronized void failPendingMessages(ClientCnx cnx, PulsarClientException ex) {
         if (cnx == null) {
             final AtomicInteger releaseCount = new AtomicInteger();
             final boolean batchMessagingEnabled = isBatchMessagingEnabled();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -50,7 +50,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -2309,7 +2308,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             // triggered by op.sendComplete(ex); don't get removed
             int pendingMessagesToFailCount = pendingMessages.size();
 
-            for(int i =0 ; i < pendingMessagesToFailCount; i++) {
+            for (int i = 0; i < pendingMessagesToFailCount; i++) {
                 OpSendMsg op = pendingMessages.remove();
                 releaseCount.addAndGet(batchMessagingEnabled ? op.numMessagesInBatch : 1);
                 try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2296,8 +2296,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     /**
-     * This fails and clears the pending messages with the given exception. This method should be called from within the
-     * ProducerImpl object mutex.
+     * This fails the pending messages at the start of the call, without dropping newly enqueued
+     * retry messages. This method should be called from within the ProducerImpl object mutex.
      */
     @VisibleForTesting
     synchronized void failPendingMessages(ClientCnx cnx, PulsarClientException ex) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -72,7 +72,7 @@ public class ProducerImplTest {
     }
 
     @Test
-    public void testFailPendingMessagesClearsReentrantRetry_whenBatchingDisabled()
+    public void testFailPendingMessagesSyncRetry()
             throws Exception {
         ProducerImpl<byte[]> producer =
                 Mockito.mock(ProducerImpl.class, Mockito.CALLS_REAL_METHODS);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -97,10 +97,9 @@ public class ProducerImplTest {
         clientField.setAccessible(true);
         clientField.set(producer, client);
 
-        // 2. OpSendMsg that retries reentrantly
+        // OpSendMsg that retries reentrantly
         MessageImpl<?> msg = Mockito.mock(MessageImpl.class);
         Mockito.when(msg.getUncompressedSize()).thenReturn(10);
-        Mockito.when(msg.getSequenceId()).thenReturn(1L);
         ProducerImpl.OpSendMsg op = ProducerImpl.OpSendMsg.create(
                 Mockito.mock(LatencyHistogram.class),
                 msg,
@@ -114,7 +113,6 @@ public class ProducerImplTest {
 
         MessageImpl<?> retryMsg = Mockito.mock(MessageImpl.class);
         Mockito.when(retryMsg.getUncompressedSize()).thenReturn(10);
-        Mockito.when(retryMsg.getSequenceId()).thenReturn(2L);
 
         // Override sendComplete to Reentrant retry via spy
         ProducerImpl.OpSendMsg firstSpy = Mockito.spy(op);
@@ -124,7 +122,7 @@ public class ProducerImplTest {
                     Mockito.mock(LatencyHistogram.class),
                     retryMsg,
                     Mockito.mock(ByteBufPair.class),
-                    1L,
+                    2L,
                     Mockito.mock(SendCallback.class)
             );
             retryOp.totalChunks = 1;
@@ -144,7 +142,7 @@ public class ProducerImplTest {
         producer.failPendingMessages(null, new PulsarClientException.TimeoutException("timeout"));
         assertEquals(producer.getPendingQueueSize(), 1,
                 "Retry Op should exist in the pending Queue");
-        assertEquals(pendingQueue.peek().msg.getSequenceId(), 2L,
-                "Retry msg should exist in the pendingQueue");
+        assertEquals(pendingQueue.peek().sequenceId, 2L,
+                "Retry Op SequenceId should match with the one in pendingQueue");
     }
 }


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #25201

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Fix a re-entrancy bug in `ProducerImpl.failPendingMessages`. While executing on the timer, `failPendingMessages` invokes `sendComplete(ex)` on pending messages, which can synchronously trigger a retry from client code. The subsequent `pendingMessages.clear()` then removes the newly enqueued retry operation, leaving the retry’s CompletableFuture unresolved and the client in a limbo state.

### Modifications

<!-- Describe the modifications you've done. -->
Updated `failPendingMessages` to first drain the `pendingMessages` queue into a local list and clear the queue before iterating. This prevents re-entrant retries triggered during sendComplete from being inadvertently cleared.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *org.apache.pulsar.client.impl.ProducerImplTest#testFailPendingMessagesSyncRetry*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
