### PR TITLE
[fix][cli] Load client.conf timeouts in CLI tools

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -92,8 +92,11 @@ webserviceTlsProvider=
 proxyServiceUrl=
 
 #Proxy protocol to select type of routing at proxy
-proxyProtocol=
+#proxyProtocol=
 
 # Pulsar Admin Custom Commands
 #customCommandFactoriesDirectory=commandFactories
 #customCommandFactories=
+
+operationTimeoutMs=5000
+lookupTimeoutMs=3000

--- a/conf/client.conf
+++ b/conf/client.conf
@@ -102,4 +102,4 @@ proxyServiceUrl=
 operationTimeoutMs=30000
 
 # Timeout for lookup operations
-lookupTimeoutMs=30000
+lookupTimeoutMs=-1

--- a/conf/client.conf
+++ b/conf/client.conf
@@ -98,5 +98,8 @@ proxyServiceUrl=
 #customCommandFactoriesDirectory=commandFactories
 #customCommandFactories=
 
-operationTimeoutMs=5000
-lookupTimeoutMs=3000
+# Timeout for client operations
+operationTimeoutMs=30000
+
+# Timeout for lookup operations
+lookupTimeoutMs=30000

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -597,19 +597,21 @@ public class PulsarClientToolTest extends BrokerTestBase {
         final int expectedLookupTimeout = 65000;
 
         Properties properties = new Properties();
-        properties.setProperty("serviceUrl", brokerUrl.toString());
+        properties.setProperty("serviceUrl", "pulsar://localhost:6650");
         properties.setProperty("operationTimeoutMs", String.valueOf(expectedOpTimeout));
         properties.setProperty("lookupTimeoutMs", String.valueOf(expectedLookupTimeout));
 
+        // Simulate the new logic in PulsarClientTool: Convert to Map
         Map<String, Object> configMap = new HashMap<>();
         for (String key : properties.stringPropertyNames()) {
             configMap.put(key, properties.getProperty(key));
         }
+
         // Apply the configuration using loadConf()
         ClientBuilderImpl builder = new ClientBuilderImpl();
         builder.loadConf(configMap);
 
-        // Extract the configuration data and assert the timeouts were updated
+        // Extract the configuration data and assert the timeouts were updated correctly
         ClientConfigurationData conf = builder.getClientConfigurationData();
         Assert.assertEquals(conf.getOperationTimeoutMs(), (long) expectedOpTimeout,
                 "operationTimeoutMs should be correctly loaded from properties");

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -593,8 +593,8 @@ public class PulsarClientToolTest extends BrokerTestBase {
 
     @Test
     public void testTimeoutConfigurationLoading() throws Exception {
-        final long expectedOpTimeout = 55000L;
-        final long expectedLookupTimeout = 65000L;
+        final int expectedOpTimeout = 55000;
+        final int expectedLookupTimeout = 65000;
 
         Properties properties = new Properties();
         properties.setProperty("serviceUrl", brokerUrl.toString());
@@ -611,10 +611,10 @@ public class PulsarClientToolTest extends BrokerTestBase {
 
         // Extract the configuration data and assert the timeouts were updated
         ClientConfigurationData conf = builder.getClientConfigurationData();
-        Assert.assertEquals(conf.getOperationTimeoutMs(), expectedOpTimeout,
-                "operationTimeoutMs should be loaded from client properties");
-        Assert.assertEquals(conf.getLookupTimeoutMs(), expectedLookupTimeout,
-                "lookupTimeoutMs should be loaded from client properties");
+        Assert.assertEquals(conf.getOperationTimeoutMs(), (long) expectedOpTimeout,
+                "operationTimeoutMs should be correctly loaded from properties");
+        Assert.assertEquals(conf.getLookupTimeoutMs(), (long) expectedLookupTimeout,
+                "lookupTimeoutMs should be correctly loaded from properties");
     }
 
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -26,6 +26,8 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -43,6 +45,8 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -585,6 +589,32 @@ public class PulsarClientToolTest extends BrokerTestBase {
         properties.setProperty("serviceUrl", brokerUrl.toString());
         properties.setProperty("useTls", "false");
         return properties;
+    }
+
+    @Test
+    public void testTimeoutConfigurationLoading() throws Exception {
+        final long expectedOpTimeout = 55000L;
+        final long expectedLookupTimeout = 65000L;
+
+        Properties properties = new Properties();
+        properties.setProperty("serviceUrl", brokerUrl.toString());
+        properties.setProperty("operationTimeoutMs", String.valueOf(expectedOpTimeout));
+        properties.setProperty("lookupTimeoutMs", String.valueOf(expectedLookupTimeout));
+
+        Map<String, Object> configMap = new HashMap<>();
+        for (String key : properties.stringPropertyNames()) {
+            configMap.put(key, properties.getProperty(key));
+        }
+        // Apply the configuration using loadConf()
+        ClientBuilderImpl builder = new ClientBuilderImpl();
+        builder.loadConf(configMap);
+
+        // Extract the configuration data and assert the timeouts were updated
+        ClientConfigurationData conf = builder.getClientConfigurationData();
+        Assert.assertEquals(conf.getOperationTimeoutMs(), expectedOpTimeout,
+                "operationTimeoutMs should be loaded from client properties");
+        Assert.assertEquals(conf.getLookupTimeoutMs(), expectedLookupTimeout,
+                "lookupTimeoutMs should be loaded from client properties");
     }
 
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -602,10 +601,8 @@ public class PulsarClientToolTest extends BrokerTestBase {
         properties.setProperty("lookupTimeoutMs", String.valueOf(expectedLookupTimeout));
 
         // Simulate the new logic in PulsarClientTool: Convert to Map
-        Map<String, Object> configMap = new HashMap<>();
-        for (String key : properties.stringPropertyNames()) {
-            configMap.put(key, properties.getProperty(key));
-        }
+        PulsarClientTool tool = new PulsarClientTool(properties);
+        Map<String, Object> configMap = tool.createConfigMap();
 
         // Apply the configuration using loadConf()
         ClientBuilderImpl builder = new ClientBuilderImpl();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -22,6 +22,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.FileInputStream;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -113,9 +115,8 @@ public class PulsarClientTool implements CommandHook {
     String tlsKeyStorePassword;
     String sslFactoryPlugin;
     String sslFactoryPluginParams;
-    String operationTimeoutMs;
-    String lookupTimeoutMs;
 
+    protected Properties clientProperties;
     protected final CommandLine commander;
     protected CmdProduce produceCommand;
     protected CmdConsume consumeCommand;
@@ -158,8 +159,7 @@ public class PulsarClientTool implements CommandHook {
         this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
         this.sslFactoryPlugin = properties.getProperty("sslFactoryPlugin");
         this.sslFactoryPluginParams = properties.getProperty("sslFactoryPluginParams");
-        this.operationTimeoutMs = properties.getProperty("operationTimeoutMs");
-        this.lookupTimeoutMs = properties.getProperty("lookupTimeoutMs");
+        this.clientProperties = properties;
         pulsarClientPropertiesProvider = PulsarClientPropertiesProvider.create(properties);
         commander.setDefaultValueProvider(pulsarClientPropertiesProvider);
         commander.addSubcommand("produce", produceCommand);
@@ -187,13 +187,12 @@ public class PulsarClientTool implements CommandHook {
         clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(rootParams.serviceURL);
 
-        Integer opTimeout = parseTimeout(this.operationTimeoutMs, "operationTimeoutMs");
-        if (opTimeout != null) {
-            clientBuilder.operationTimeout(opTimeout, java.util.concurrent.TimeUnit.MILLISECONDS);
-        }
-        Integer lookupTimeout = parseTimeout(this.lookupTimeoutMs, "lookupTimeoutMs");
-        if (lookupTimeout != null) {
-            clientBuilder.lookupTimeout(lookupTimeout, java.util.concurrent.TimeUnit.MILLISECONDS);
+        if (this.clientProperties != null) {
+            Map<String, Object> configMap = new HashMap<>();
+            for (String key : this.clientProperties.stringPropertyNames()) {
+                configMap.put(key, this.clientProperties.getProperty(key));
+            }
+            clientBuilder.loadConf(configMap);
         }
 
         clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath)
@@ -222,18 +221,6 @@ public class PulsarClientTool implements CommandHook {
         this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.readCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         return 0;
-    }
-
-    private Integer parseTimeout(String timeoutStr, String propertyName) {
-        if (isNotBlank(timeoutStr)) {
-            try {
-                return Integer.parseInt(timeoutStr.trim());
-            } catch (NumberFormatException e) {
-                commander.getErr().println("Warning: Invalid " + propertyName + " value '"
-                        + timeoutStr + "' in client.conf. Using default value.");
-            }
-        }
-        return null;
     }
 
     public int run(String[] args) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -188,11 +188,7 @@ public class PulsarClientTool implements CommandHook {
         clientBuilder.serviceUrl(rootParams.serviceURL);
 
         if (this.clientProperties != null) {
-            Map<String, Object> configMap = new HashMap<>();
-            for (String key : this.clientProperties.stringPropertyNames()) {
-                configMap.put(key, this.clientProperties.getProperty(key));
-            }
-            clientBuilder.loadConf(configMap);
+            clientBuilder.loadConf(createConfigMap());
         }
 
         clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath)
@@ -221,6 +217,17 @@ public class PulsarClientTool implements CommandHook {
         this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.readCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         return 0;
+    }
+
+    @VisibleForTesting
+    Map<String, Object> createConfigMap() {
+        Map<String, Object> configMap = new HashMap<>();
+        if (this.clientProperties != null) {
+            for (String key : this.clientProperties.stringPropertyNames()) {
+                configMap.put(key, this.clientProperties.getProperty(key));
+            }
+        }
+        return configMap;
     }
 
     public int run(String[] args) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -113,6 +113,8 @@ public class PulsarClientTool implements CommandHook {
     String tlsKeyStorePassword;
     String sslFactoryPlugin;
     String sslFactoryPluginParams;
+    String operationTimeoutMs;
+    String lookupTimeoutMs;
 
     protected final CommandLine commander;
     protected CmdProduce produceCommand;
@@ -156,7 +158,8 @@ public class PulsarClientTool implements CommandHook {
         this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
         this.sslFactoryPlugin = properties.getProperty("sslFactoryPlugin");
         this.sslFactoryPluginParams = properties.getProperty("sslFactoryPluginParams");
-
+        this.operationTimeoutMs = properties.getProperty("operationTimeoutMs");
+        this.lookupTimeoutMs = properties.getProperty("lookupTimeoutMs");
         pulsarClientPropertiesProvider = PulsarClientPropertiesProvider.create(properties);
         commander.setDefaultValueProvider(pulsarClientPropertiesProvider);
         commander.addSubcommand("produce", produceCommand);
@@ -184,6 +187,11 @@ public class PulsarClientTool implements CommandHook {
         clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(rootParams.serviceURL);
 
+        applyCustomTimeout(this.operationTimeoutMs, "operationTimeoutMs",
+                timeout -> clientBuilder.operationTimeout(timeout, java.util.concurrent.TimeUnit.MILLISECONDS));
+        applyCustomTimeout(this.lookupTimeoutMs, "lookupTimeoutMs",
+                timeout -> clientBuilder.lookupTimeout(timeout, java.util.concurrent.TimeUnit.MILLISECONDS));
+
         clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath)
                 .tlsKeyFilePath(tlsKeyFilePath)
                 .tlsCertificateFilePath(tlsCertificateFilePath);
@@ -210,6 +218,19 @@ public class PulsarClientTool implements CommandHook {
         this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.readCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         return 0;
+    }
+
+    private void applyCustomTimeout(String timeoutStr, String propertyName,
+                                    java.util.function.IntConsumer timeoutSetter) {
+        if (isNotBlank(timeoutStr)) {
+            try {
+                int timeout = Integer.parseInt(timeoutStr.trim());
+                timeoutSetter.accept(timeout);
+            } catch (NumberFormatException e) {
+                commander.getErr().println("Warning: Invalid " + propertyName + " value '"
+                        + timeoutStr + "' in client.conf. Using default value.");
+            }
+        }
     }
 
     public int run(String[] args) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -222,10 +222,8 @@ public class PulsarClientTool implements CommandHook {
     @VisibleForTesting
     Map<String, Object> createConfigMap() {
         Map<String, Object> configMap = new HashMap<>();
-        if (this.clientProperties != null) {
-            for (String key : this.clientProperties.stringPropertyNames()) {
+        for (String key : this.clientProperties.stringPropertyNames()) {
                 configMap.put(key, this.clientProperties.getProperty(key));
-            }
         }
         return configMap;
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -187,10 +187,14 @@ public class PulsarClientTool implements CommandHook {
         clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(rootParams.serviceURL);
 
-        applyCustomTimeout(this.operationTimeoutMs, "operationTimeoutMs",
-                timeout -> clientBuilder.operationTimeout(timeout, java.util.concurrent.TimeUnit.MILLISECONDS));
-        applyCustomTimeout(this.lookupTimeoutMs, "lookupTimeoutMs",
-                timeout -> clientBuilder.lookupTimeout(timeout, java.util.concurrent.TimeUnit.MILLISECONDS));
+        Integer opTimeout = parseTimeout(this.operationTimeoutMs, "operationTimeoutMs");
+        if (opTimeout != null) {
+            clientBuilder.operationTimeout(opTimeout, java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+        Integer lookupTimeout = parseTimeout(this.lookupTimeoutMs, "lookupTimeoutMs");
+        if (lookupTimeout != null) {
+            clientBuilder.lookupTimeout(lookupTimeout, java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
 
         clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath)
                 .tlsKeyFilePath(tlsKeyFilePath)
@@ -220,17 +224,16 @@ public class PulsarClientTool implements CommandHook {
         return 0;
     }
 
-    private void applyCustomTimeout(String timeoutStr, String propertyName,
-                                    java.util.function.IntConsumer timeoutSetter) {
+    private Integer parseTimeout(String timeoutStr, String propertyName) {
         if (isNotBlank(timeoutStr)) {
             try {
-                int timeout = Integer.parseInt(timeoutStr.trim());
-                timeoutSetter.accept(timeout);
+                return Integer.parseInt(timeoutStr.trim());
             } catch (NumberFormatException e) {
                 commander.getErr().println("Warning: Invalid " + propertyName + " value '"
                         + timeoutStr + "' in client.conf. Using default value.");
             }
         }
+        return null;
     }
 
     public int run(String[] args) {


### PR DESCRIPTION
Fixes [apache#22808](https://github.com/apache/pulsar/issues/22808)

### Motivation

Pulsar CLI tools (`pulsar-client` and `pulsar-perf`) are not picking up timeout configurations from `conf/client.conf`.

Even when `lookupTimeoutMs` and `operationTimeoutMs` are explicitly set, the CLI continues to use default values:

- `"operationTimeoutMs": 30000`
- `"lookupTimeoutMs": 30000`

This is because these properties are not being properly loaded and applied to the internal `ClientBuilder`.

As a result, user-defined timeout configurations are ignored at runtime, unlike the Java client where the same settings work as expected.


### Modifications

- Loaded `operationTimeoutMs` and `lookupTimeoutMs` explicitly from `Properties`
- Parsed and applied them to:
  - `clientBuilder.operationTimeout(...)`
  - `clientBuilder.lookupTimeout(...)`
- Added basic validation (`isNotBlank`, `trim`) before parsing
- Handled invalid values using `try-catch (NumberFormatException)`
- Logged a warning via `commander.getErr().println()` and fallback to defaults when parsing fails


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `testTimeoutConfigurationLoading` in `PulsarClientToolTest`
- Injected custom timeout values (55000, 65000) via `Properties`
- Verified that `ClientConfigurationData` reflects the configured values instead of defaults


### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)  
- [ ] The public API  
- [ ] The schema  
- [ ] The default values of configurations  
- [ ] The threading model  
- [ ] The binary protocol  
- [ ] The REST endpoints  
- [x] The admin CLI options  
- [ ] The metrics  
- [ ] Anything that affects deployment  