### PR TITLE
[fix][io] Resolve Debezium Postgres CDC schema mismatch and consolidate config mappings

### DIFF
--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium;
 
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -76,12 +77,41 @@ public abstract class DebeziumSource extends KafkaConnectSource {
 
     public abstract void setDbConnectorTask(Map<String, Object> config) throws Exception;
 
+    public static void applyConfigMappings(Map<String, Object> config) {
+        // Translate database.server.name to topic.prefix
+        if (config.containsKey("database.server.name") && !config.containsKey("topic.prefix")) {
+            config.put("topic.prefix", config.get("database.server.name"));
+            log.warn("Property 'database.server.name' is deprecated in Debezium 2.x. Auto-mapped to 'topic.prefix'");
+        }
+
+        // Translate topic.prefix back to database.server.name
+        if (config.containsKey("topic.prefix") && !config.containsKey("database.server.name")) {
+            config.put("database.server.name", config.get("topic.prefix"));
+            log.warn("Auto-mapped 'topic.prefix' to 'database.server.name' for internal validator compatibility");
+        }
+
+        // Translate table.whitelist to table.include.list
+        if (config.containsKey("table.whitelist") && !config.containsKey("table.include.list")) {
+            config.put("table.include.list", config.get("table.whitelist"));
+            log.warn("Property 'table.whitelist' is deprecated in Debezium 2.x. Auto-mapped to 'table.include.list'");
+        }
+
+        // Translate schema.whitelist to schema.include.list
+        if (config.containsKey("schema.whitelist") && !config.containsKey("schema.include.list")) {
+            config.put("schema.include.list", config.get("schema.whitelist"));
+            log.warn("Property 'schema.whitelist' is deprecated in Debezium 2.x. Auto-mapped to 'schema.include.list'");
+        }
+    }
+
     @Override
-    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+    public void open(Map<String, Object> incomingConfig, SourceContext sourceContext) throws Exception {
+        Map<String, Object> config = new HashMap<>(incomingConfig);
         setDbConnectorTask(config);
         tryLoadingConfigSecret("database.user", config, sourceContext);
         tryLoadingConfigSecret("database.password", config, sourceContext);
 
+        // Apply backward compatibility mappings
+        applyConfigMappings(config);
         // key.converter
         setConfigIfNull(config, PulsarKafkaWorkerConfig.KEY_CONVERTER_CLASS_CONFIG, DEFAULT_CONVERTER);
         // value.converter

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/DebeziumSourceTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/DebeziumSourceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.debezium;
+
+import static org.testng.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Test the config mapping logic in {@link DebeziumSource}.
+ */
+public class DebeziumSourceTest {
+
+    @Test
+    public void testTopicPrefixMappedToServerName() {
+        // database.server.name must be auto-mapped for internal validator
+        Map<String, Object> config = new HashMap<>();
+        config.put("topic.prefix", "dbserver1");
+
+        DebeziumSource.applyConfigMappings(config);
+
+        assertEquals(config.get("database.server.name"), "dbserver1",
+            "database.server.name should be auto-mapped from topic.prefix");
+    }
+
+    @Test
+    public void testServerNameMappedToTopicPrefix() {
+        // topic.prefix must be auto-mapped
+        Map<String, Object> config = new HashMap<>();
+        config.put("database.server.name", "dbserver1");
+
+        DebeziumSource.applyConfigMappings(config);
+
+        assertEquals(config.get("topic.prefix"), "dbserver1",
+            "topic.prefix should be auto-mapped from database.server.name");
+    }
+
+    @Test
+    public void testTableWhitelistMappedToIncludeList() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("table.whitelist", "public.users");
+
+        DebeziumSource.applyConfigMappings(config);
+
+        assertEquals(config.get("table.include.list"), "public.users",
+            "table.include.list should be auto-mapped from table.whitelist");
+    }
+
+    @Test
+    public void testSchemaWhitelistMappedToIncludeList() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("schema.whitelist", "public");
+
+        DebeziumSource.applyConfigMappings(config);
+
+        assertEquals(config.get("schema.include.list"), "public",
+            "schema.include.list should be auto-mapped from schema.whitelist");
+    }
+
+    @Test
+    public void testExistingValuesNotOverwritten() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("topic.prefix", "prefix1");
+        config.put("database.server.name", "server1");
+
+        DebeziumSource.applyConfigMappings(config);
+
+        assertEquals(config.get("topic.prefix"), "prefix1");
+        assertEquals(config.get("database.server.name"), "server1");
+    }
+}


### PR DESCRIPTION
Fixes [apache#23662](https://github.com/apache/pulsar/issues/23662)

### Motivation

The documented Debezium PostgreSQL CDC example does not work as expected in Pulsar 4.0.0. Although the connector starts successfully and receives database changes, no messages are published to the Pulsar topic, causing the documented workflow to fail silently.

This happens due to multiple issues:

- The example does not specify `--destination-topic-name`, so captured CDC events are not routed to a Pulsar topic.
- The connector configuration relies on legacy Debezium property names, while newer configurations commonly use `topic.prefix`, leading to validation failures when `database.server.name` is not present.
- Default schema handling can trigger compatibility issues when Debezium publishes complex `KeyValue` schemas.

As a result, users following the official documentation are unable to consume CDC messages from the generated topic.


### Modifications

- Updated the PostgreSQL Debezium source documentation to include `--destination-topic-name` in the `localrun` example.
- Added configuration guidance for schema compatibility using:

  - `pulsar.schema.compatibility.strategy=ALWAYS_COMPATIBLE`

- Improved Debezium configuration mapping logic to support `topic.prefix` when `database.server.name` is not explicitly provided.
- Consolidated backward-compatibility property translations for legacy and newer Debezium configuration formats.
- Added/updated tests to validate configuration mapping behavior.


### Verifying this change

This change was verified manually using:

- Apache Pulsar 4.0.0 standalone
- `pulsar-io-debezium-postgres-4.0.0.nar`
- PostgreSQL 13.3 (Docker)

Validation steps:

- Started PostgreSQL with logical replication enabled
- Ran the documented `localrun` command with updated configuration
- Performed INSERT / UPDATE / DELETE operations on the source table
- Confirmed messages were successfully published and consumed from:

`persistent://public/default/dbserver1.public.users`

Example consumer output included CDC events with:

```text
----- got message -----
key:[eyJpZC0=]
content:{"before":null,"after":{"id":6,"hash_firstname":"initial-rs"},
"source":{"connector":"postgresql","name":"dbserver1"},
"op":"c","ts_ms":1776669145647}

- `"op":"c"` for inserts
- `"op":"u"` for updates
- `"op":"d"` for deletes
```

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment