### PR TITLE
[fix][test] Fix flaky OneWayReplicatorDeduplicationTest.testDeduplication

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
@@ -114,6 +114,7 @@ public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase 
                                      LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
         super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
         // For check whether deduplication snapshot has done.
+        config.setBrokerDeduplicationSnapshotIntervalSeconds(1);
         config.setBrokerDeduplicationEntriesInterval(10);
         config.setReplicationStartAt("earliest");
         // To cover more cases, write more than one ledger.


### PR DESCRIPTION
Fixes [apache#25141](https://github.com/apache/pulsar/issues/25141)

### Motivation

`OneWayReplicatorDeduplicationTest.testDeduplication` is flaky because `MessageDeduplication.takeSnapshot` is designed to drop concurrent snapshot requests if an existing snapshot operation is already in progress. The test relies on specific positions being persisted, but if a manual trigger is dropped due to this intentional "lossy" design, the test fails with a `ConditionTimeoutException` while waiting for the state to update.

### Modifications

- Modified `OneWayReplicatorDeduplicationTest` to set `brokerDeduplicationSnapshotIntervalSeconds` to 1 second in the test configuration.

- By increasing the frequency of the background snapshot monitor, the system is guaranteed to capture and persist the deduplication state frequently enough to satisfy the test's assertions, even if a specific manual trigger request is skipped due to a race condition.

### Verifying this change

- Verified that the flaky test now runs consistently without failures.
- Confirmed that the 1-second background interval provides a sufficient "safety net" to persist the state when concurrent manual triggers are dropped.
- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:

- `org.apache.pulsar.broker.service.OneWayReplicatorDeduplicationTest.testDeduplication`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment