### PR TITLE
[cleanup][broker] Standardize java.time.Clock usage in broker service

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -61,6 +61,7 @@ public class PulsarStats implements Closeable {
     private final boolean exposePublisherStats;
 
     private final ReentrantReadWriteLock bufferLock = new ReentrantReadWriteLock();
+    private final PulsarService pulsar;
 
     @Getter
     private long updatedAt;
@@ -81,6 +82,7 @@ public class PulsarStats implements Closeable {
 
         this.exposePublisherStats = pulsar.getConfiguration().isExposePublisherStats();
         this.updatedAt = 0;
+        this.pulsar = pulsar;
 
     }
 
@@ -230,7 +232,7 @@ public class PulsarStats implements Closeable {
         } finally {
             bufferLock.writeLock().unlock();
         }
-        updatedAt = System.currentTimeMillis();
+        updatedAt = this.pulsar.getClock().millis();
     }
 
     public synchronized NamespaceBundleStats invalidBundleStats(String bundleName) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import java.io.Closeable;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class PulsarStats implements Closeable {
     private final boolean exposePublisherStats;
 
     private final ReentrantReadWriteLock bufferLock = new ReentrantReadWriteLock();
-    private final PulsarService pulsar;
+    private final Clock clock;
 
     @Getter
     private long updatedAt;
@@ -82,8 +83,7 @@ public class PulsarStats implements Closeable {
 
         this.exposePublisherStats = pulsar.getConfiguration().isExposePublisherStats();
         this.updatedAt = 0;
-        this.pulsar = pulsar;
-
+        this.clock = pulsar.getClock();
     }
 
     @Override
@@ -232,7 +232,7 @@ public class PulsarStats implements Closeable {
         } finally {
             bufferLock.writeLock().unlock();
         }
-        updatedAt = this.pulsar.getClock().millis();
+        updatedAt = this.clock.millis();
     }
 
     public synchronized NamespaceBundleStats invalidBundleStats(String bundleName) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -25,6 +25,7 @@ import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_
 import com.google.common.annotations.VisibleForTesting;
 import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
+import java.time.Clock;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,7 @@ public class MessageDeduplication {
     private final PersistentTopic topic;
     private final ManagedLedger managedLedger;
     private final ManagedLedgerReplayTask replayTask;
+    private final Clock clock;
     private ManagedCursor managedCursor;
 
     private static final String IS_LAST_CHUNK = "isLastChunk";
@@ -144,6 +146,7 @@ public class MessageDeduplication {
         this.maxNumberOfProducers = pulsar.getConfiguration().getBrokerDeduplicationMaxNumberOfProducers();
         this.snapshotCounter = 0;
         this.replicatorPrefix = pulsar.getConfiguration().getReplicatorPrefix();
+        this.clock = pulsar.getClock();
         this.replayTask = new ManagedLedgerReplayTask("MessageDeduplication", pulsar.getExecutor(), 100);
         this.log = LOG.with().attr("topic", topic.getName()).build();
     }
@@ -601,7 +604,7 @@ public class MessageDeduplication {
             log.debug()
                     .attr("position", position)
                     .log("Stored new deduplication snapshot at");
-            lastSnapshotTimestamp = pulsar.getClock().millis();
+            lastSnapshotTimestamp = this.clock.millis();
             snapshotTaking.set(false);
         });
         future.exceptionally(e -> {
@@ -636,14 +639,14 @@ public class MessageDeduplication {
         }
 
         // Producer is no-longer active
-        inactiveProducers.put(producerName, pulsar.getClock().millis());
+        inactiveProducers.put(producerName, this.clock.millis());
     }
 
     /**
      * Remove from hash maps all the producers that were inactive for more than the configured amount of time.
      */
     public synchronized void purgeInactiveProducers() {
-        long minimumActiveTimestamp = pulsar.getClock().millis() - TimeUnit.MINUTES
+        long minimumActiveTimestamp = this.clock.millis() - TimeUnit.MINUTES
                 .toMillis(pulsar.getConfiguration().getBrokerDeduplicationProducerInactivityTimeoutMinutes());
 
         // if not enabled just clear all inactive producer record.
@@ -687,7 +690,7 @@ public class MessageDeduplication {
         }
 
         Integer interval = topic.getHierarchyTopicPolicies().getDeduplicationSnapshotIntervalSeconds().get();
-        long currentTimeStamp = pulsar.getClock().millis();
+        long currentTimeStamp = this.clock.millis();
         if (interval == null || interval <= 0
                 || currentTimeStamp - lastSnapshotTimestamp < TimeUnit.SECONDS.toMillis(interval)) {
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -601,7 +601,7 @@ public class MessageDeduplication {
             log.debug()
                     .attr("position", position)
                     .log("Stored new deduplication snapshot at");
-            lastSnapshotTimestamp = System.currentTimeMillis();
+            lastSnapshotTimestamp = pulsar.getClock().millis();
             snapshotTaking.set(false);
         });
         future.exceptionally(e -> {
@@ -636,14 +636,14 @@ public class MessageDeduplication {
         }
 
         // Producer is no-longer active
-        inactiveProducers.put(producerName, System.currentTimeMillis());
+        inactiveProducers.put(producerName, pulsar.getClock().millis());
     }
 
     /**
      * Remove from hash maps all the producers that were inactive for more than the configured amount of time.
      */
     public synchronized void purgeInactiveProducers() {
-        long minimumActiveTimestamp = System.currentTimeMillis() - TimeUnit.MINUTES
+        long minimumActiveTimestamp = pulsar.getClock().millis() - TimeUnit.MINUTES
                 .toMillis(pulsar.getConfiguration().getBrokerDeduplicationProducerInactivityTimeoutMinutes());
 
         // if not enabled just clear all inactive producer record.
@@ -687,7 +687,7 @@ public class MessageDeduplication {
         }
 
         Integer interval = topic.getHierarchyTopicPolicies().getDeduplicationSnapshotIntervalSeconds().get();
-        long currentTimeStamp = System.currentTimeMillis();
+        long currentTimeStamp = pulsar.getClock().millis();
         if (interval == null || interval <= 0
                 || currentTimeStamp - lastSnapshotTimestamp < TimeUnit.SECONDS.toMillis(interval)) {
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
@@ -25,6 +25,7 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -106,7 +107,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
     private static final Summary putOpsLatency = buildSummary("pulsar_schema_put_ops_latency", "-");
 
     private final Map<String, Long> namespaceAccess = new ConcurrentHashMap<>();
-    private final PulsarService pulsarService;
+    private final Clock clock;
     private final ScheduledFuture<?> future;
 
     public SchemaRegistryStats(PulsarService pulsarService) {
@@ -121,7 +122,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
                 .setDescription("The number of Schema Registry compatibility check operations performed by the broker.")
                 .setUnit("{operation}")
                 .build();
-        this.pulsarService = pulsarService;
+        this.clock = pulsarService.getClock();
     }
 
     private static Summary buildSummary(String name, String help) {
@@ -214,7 +215,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
             namespace = "unknown";
         }
 
-        this.namespaceAccess.put(namespace, this.pulsarService.getClock().millis());
+        this.namespaceAccess.put(namespace, this.clock.millis());
         return namespace;
     }
 
@@ -238,7 +239,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
 
     @Override
     public void run() {
-        long now = this.pulsarService.getClock().millis();
+        long now = this.clock.millis();
         long interval = TimeUnit.MINUTES.toMillis(5);
 
         this.namespaceAccess.entrySet().removeIf(entry -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryStats.java
@@ -106,6 +106,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
     private static final Summary putOpsLatency = buildSummary("pulsar_schema_put_ops_latency", "-");
 
     private final Map<String, Long> namespaceAccess = new ConcurrentHashMap<>();
+    private final PulsarService pulsarService;
     private final ScheduledFuture<?> future;
 
     public SchemaRegistryStats(PulsarService pulsarService) {
@@ -120,6 +121,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
                 .setDescription("The number of Schema Registry compatibility check operations performed by the broker.")
                 .setUnit("{operation}")
                 .build();
+        this.pulsarService = pulsarService;
     }
 
     private static Summary buildSummary(String name, String help) {
@@ -212,7 +214,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
             namespace = "unknown";
         }
 
-        this.namespaceAccess.put(namespace, System.currentTimeMillis());
+        this.namespaceAccess.put(namespace, this.pulsarService.getClock().millis());
         return namespace;
     }
 
@@ -236,7 +238,7 @@ class SchemaRegistryStats implements AutoCloseable, Runnable {
 
     @Override
     public void run() {
-        long now = System.currentTimeMillis();
+        long now = this.pulsarService.getClock().millis();
         long interval = TimeUnit.MINUTES.toMillis(5);
 
         this.namespaceAccess.entrySet().removeIf(entry -> {


### PR DESCRIPTION
Fixes [apache#25660](https://github.com/apache/pulsar/issues/25660)

### Motivation

The usage of `java.time.Clock` is currently inconsistent across the broker module, with many classes directly relying on `System.currentTimeMillis()` for timestamp generation.

Standardizing timestamp handling through the centralized `PulsarService` clock improves consistency across the codebase and makes time-dependent behavior easier to control during testing. This reduces test flakiness by enabling deterministic time mocking in unit and integration tests.

Because there are hundreds of occurrences of `System.currentTimeMillis()` across the repository, this PR intentionally scopes the change to a tightly focused set of classes. It specifically targets classes where the `Clock` dependency can be cleanly injected via the constructor, ensuring a clear separation of concerns and keeping the review safe and manageable.

### Modifications

Replaced direct usages of System.currentTimeMillis() with this.clock.millis() by utilizing field injection for the Clock dependency in the following broker module classes:

- `MessageDeduplication.java`
- `SchemaRegistryStats.java`
- `PulsarStats.java`

Additional changes:
- Left existing `System.nanoTime()` usages unchanged, as they are used for monotonic latency measurements rather than wall-clock timestamps.

### Verifying this change

This change can be verified as follows:

- Confirmed successful compilation and that existing broker tests continue to pass.
- Verified timestamp-related logic in the modified classes now consistently uses the centralized broker clock via constructor injection.
- Confirmed no behavioral changes in latency-related code paths using `System.nanoTime()`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment